### PR TITLE
fix max pixel ratio

### DIFF
--- a/alipaygame/game.js
+++ b/alipaygame/game.js
@@ -9,7 +9,7 @@ require(window._CCSettings.debug ? './cocos2d-js' : './cocos2d-js-min');
 require('./adapter/engine/index');
 
 // Adjust devicePixelRatio
-cc.view._maxPixelRatio = 3;
+cc.view._maxPixelRatio = 4;
 
 myDownloader.REMOTE_SERVER_ROOT = "";
 myDownloader.SUBCONTEXT_ROOT = "";


### PR DESCRIPTION
changeLog:
- 修复支付宝平台在部分高分辨率手机的屏幕适配问题

三星 s9 的 pixelRatio 是 3.5
![图片](https://user-images.githubusercontent.com/17872773/62508106-0a7b2500-b839-11e9-8f24-8b95710e00ce.png)
![2](https://user-images.githubusercontent.com/17872773/62508122-1b2b9b00-b839-11e9-86dc-27a5a96e6098.png)
