### PR TITLE
require index script after subpackage loaded

### DIFF
--- a/alipaygame/adapter/engine/downloader.js
+++ b/alipaygame/adapter/engine/downloader.js
@@ -1,5 +1,11 @@
+let loadedSubPackages = {};
+
 cc.loader.downloader.loadSubpackage = function (name, completeCallback) {
     // Not support for now on Alipay platform
+    if (loadedSubPackages[name] !== true) {
+        require(`../../subpackages/${name}/index.js`);
+        loadedSubPackages[name] = true;
+    }
     completeCallback && completeCallback();
 };
 


### PR DESCRIPTION
Re: https://github.com/cocos-creator/2d-tasks/issues/1726

changeLog:
- 修复 cc.loader.downloader.loadSubpackage 没有执行入口脚本的问题