### PR TITLE
fix Label black border on Alipay

### DIFF
--- a/alipaygame/adapter/engine/Label.js
+++ b/alipaygame/adapter/engine/Label.js
@@ -1,0 +1,37 @@
+if (cc && cc.Label) {
+    const isDevTool = window.navigator && (/AlipayIDE/.test(window.navigator.userAgent));
+    const gfx = cc.gfx;
+    const Label = cc.Label;
+
+    Object.assign(Label.prototype, {
+        setMaterial (index, material) {
+            cc.RenderComponent.prototype.setMaterial.call(this, index, material);
+
+            // init blend factor
+            let dstBlendFactor = cc.macro.BlendFactor.ONE_MINUS_SRC_ALPHA;
+            let srcBlendFactor;
+            if (!(isDevTool || this.font instanceof cc.BitmapFont)) {
+                // Premultiplied alpha on runtime
+                srcBlendFactor = cc.macro.BlendFactor.ONE;
+            }
+            else {
+                srcBlendFactor = cc.macro.BlendFactor.SRC_ALPHA;
+            }
+
+            // set blend func
+            let passes = material._effect.getDefaultTechnique().passes;
+            for (let j = 0; j < passes.length; j++) {
+                let pass = passes[j];
+                pass.setBlend(
+                    true,
+                    gfx.BLEND_FUNC_ADD,
+                    srcBlendFactor, dstBlendFactor,
+                    gfx.BLEND_FUNC_ADD,
+                    srcBlendFactor, dstBlendFactor,
+                );
+            }
+
+            material.setDirty(true);
+        },
+    });
+}

--- a/alipaygame/adapter/engine/index.js
+++ b/alipaygame/adapter/engine/index.js
@@ -6,3 +6,4 @@ require('./downloader');
 require('./misc');
 require('./InputManager');
 require('./Texture2D');
+require('./Label');


### PR DESCRIPTION
Re: https://github.com/cocos-creator/2d-tasks/issues/1750

changeLog:
- 修复支付宝上 label 字体渲染黑边问题

说明： 支付宝 runtime 上，由于字体颜色跟透明黑色背景混合 rgba(0,0,0,0)
相当于字体颜色做了预乘 alpha
所以 js 层的渲染应该用  src: ONE dst: ONE_MINUS_SRC_ALPHA