### PR TITLE
restrict max audio instance

### DIFF
--- a/alipaygame/adapter/engine/misc.js
+++ b/alipaygame/adapter/engine/misc.js
@@ -1,6 +1,6 @@
 // cc.AuidioEngine
 if (cc && cc.audioEngine) {
-    cc.audioEngine._maxAudioInstance = 10;
+    cc.audioEngine._maxAudioInstance = 6;
 }
 
 // cc.Macro


### PR DESCRIPTION
Re: https://github.com/cocos-creator/2d-tasks/issues/2003

changeLog:
- 限制支付宝最大音频数量为 6 个

<img width="673" alt="20191101114129" src="https://user-images.githubusercontent.com/17872773/68000832-923bc880-fc9c-11e9-8536-1694559d67a7.png">
